### PR TITLE
feat: add stream consumer and producer

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,3 @@
+# Number of spaces per tab.
+# Default: 4
+tab_spaces = 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,36 @@
+sudo: false
+language: rust
+
+sercices:
+  - redis-server
+
+# Prevents cargo's cache from growing to large, see https://levans.fr/rust_travis_cache.html
+# Need to cache the whole `.cargo` directory to keep .crates.toml for
+# cargo-update to work
+cache:
+  directories:
+    - /home/travis/.cargo
+
+# But don't cache the cargo registry
+before_cache: rm -rf /home/travis/.cargo/registry
+
+matrix:
+  include:
+    - rust: stable
+      env: RUST_VERSION=stable COMMAND=test
+
+    - rust: beta
+      env: RUST_VERSION=beta COMMAND=test
+
+    - rust: nightly
+      env: RUST_VERSION=nightly COMMAND=test
+
+    - rust: stable
+      env: COMMAND=check
+
+script:
+  - make $COMMAND
+  - make check-code
+
+notifications:
+  email: false

--- a/.versionrc
+++ b/.versionrc
@@ -1,0 +1,8 @@
+{
+  "bumpFiles": [
+    {
+      "filename": "VERSION",
+      "type": "plain-text"
+    }
+  ]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,40 @@
+## Contributing
+
+First, thank you for contributing! Pull requests are always welcome!
+
+### Git Commits
+
+Please ensure your commits are small and focused; they should tell a story of your change. This helps reviewers to follow your changes, especially for more complex changes.
+
+### Github Pull Requests
+
+Once your changes are ready, submit your branch as a pull request.
+
+The pull request title must follow the format outlined in the [conventional commits spec](https://www.conventionalcommits.org):
+
+```
+<type>: <description>
+```
+
+[Conventional commits](https://www.conventionalcommits.org) is a standardized format for commit messages. We use it to update the Changelog with each commit message and upgrade the package version.
+
+As we squashes commits before merging branches, only the pull request title must conform to this format.
+
+The following are all good examples of pull request titles:
+
+```text
+feat: add for bar baz feature
+fix: fix foo bar baz bug
+chore: improve build process
+docs: fix typos
+```
+
+If your commit introduce a breaking change, append a `!` after the `type`:
+
+```text
+chore!: drop support for foo bar baz
+```
+
+Thanks! :heart: :heart: :heart:
+
+The Klaxit Team

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,11 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1.0.31"
+redis = "0.16.0"
+# We need this untill redis >= 0.16.1 is released
+redis-streams = "0.1.1"
+
+[dev-dependencies]
+rand = "0.7"
+regex = "1.3.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,21 +2,22 @@
 name = "redis-stream"
 version = "0.0.0"
 authors = ["Jean-Paul Bonnetouche <dev@klaxit.com>"]
-keywords = ["redis", "database", "stream"]
+keywords = ["redis", "database", "stream", "consumer groups"]
 description = "Stream and consume data from redis streams."
+homepage = "https://github.com/klaxit/redis-stream-rs"
 repository = "https://github.com/klaxit/redis-stream-rs"
+documentation = "https://docs.rs/redis-stream"
 license = "MIT"
 readme = "README.md"
 edition = "2018"
+include = ["src/**/*", "LICENSE", "README.md", "CHANGELOG.md"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 anyhow = "1.0.31"
-redis = "0.16.0"
-# We need this untill redis >= 0.16.1 is released
-redis-streams = "0.1.1"
+redis = "0.17.0"
 
 [dev-dependencies]
 rand = "0.7"
-regex = "1.3.9"
+regex = "1.4.1"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,46 @@
+.PHONY: $(MAKECMDGOALS) help
+.DEFAULT_GOAL := help
+
+FMT_TITLE='\\033[1m'
+FMT_PRIMARY='\\033[36m'
+FMT_END='\\033[0m'
+help:
+	@awk 'BEGIN {FS = ":.*##"; printf "Usage: make $(FMT_PRIMARY)<target>$(FMT_END)\n"} \
+	/^[a-zA-Z0-9_-]+:.*?##/ { printf "  $(FMT_PRIMARY)%-46s$(FMT_END) %s\n", $$1, $$2 } \
+	/^##@/ { printf "\n$(FMT_TITLE)%s$(FMT_END)\n", substr($$0, 5) } \
+	' $(MAKEFILE_LIST)
+
+all: check test ## Run all tests and checks
+
+##@ Testing
+
+test: test-unit ## Test everything
+
+test-unit: ## Run the unit test suite (require Redis)
+	cargo test -- --nocapture
+
+##@ Checking
+
+check: check-code check-clippy check-fmt ## Check everything
+
+check-code: ## Check code
+	cargo check --all-features
+
+check-clippy: ## Check code with Clippy
+	@rustup component add clippy 2> /dev/null
+	cargo clippy --all-targets --all-features -- -D warnings
+
+check-fmt: ## Check that all files are formatted properly
+	@rustup component add rustfmt 2> /dev/null
+	cargo fmt -- --check
+
+##@ Utility
+
+clean: ## Clean everything
+	cargo clean
+
+doc: ## Generate documentation
+	cargo doc --all-features --no-deps
+
+fmt: ## Format code
+	cargo fmt

--- a/README.md
+++ b/README.md
@@ -5,6 +5,14 @@ This project is a slightly modified port of the Elixir
 [Redix.Stream](https://github.com/compound-finance/redix_stream) library to Rust
 and comes as an extension of [redis-rs](https://github.com/mitsuhiko/redis-rs).
 
+## Installation
+
+The crate is called `redis-stream` and you can depend on it via cargo:
+
+```ini
+[dependencies]
+redis-stream = "0.1.0"
+```
 ## License
 
 Please see [LICENSE](./LICENSE)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Redis Stream
-Stream and consume data from redis streams.
+
+[![Build Status](https://travis-ci.org/klaxit/redis-stream-rs.svg?branch=master)](https://travis-ci.org/klaxit/redis-stream-rs)
+[![crates.io](http://meritbadge.herokuapp.com/redis-stream)](https://crates.io/crates/redis-stream)
+
+A Rust high-level library to consume data from Redis streams.
 
 This project is a slightly modified port of the Elixir
 [Redix.Stream](https://github.com/compound-finance/redix_stream) library to Rust
@@ -12,6 +16,88 @@ The crate is called `redis-stream` and you can depend on it via cargo:
 ```ini
 [dependencies]
 redis-stream = "0.1.0"
+```
+
+## Documentation
+
+Documentation on the library can be found at
+[docs.rs/redis-stream](https://docs.rs/redis-stream).
+
+## Basic usage:
+
+```rust
+use redis_stream::consumer::{Consumer, ConsumerOpts, Message};
+
+let redis_url =
+  std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://127.0.0.1:6379".to_string());
+
+let mut redis = redis::Client::open(redis_url)
+  .expect("client")
+  .get_connection()
+  .expect("connection");
+
+// Message handler
+let handler = |_id: &str, message: &Message| {
+  // do something
+  Ok(())
+};
+
+// Consumer config
+let opts = ConsumerOpts::default();
+let mut consumer = Consumer::init(&mut redis, "my-stream", handler, opts).expect("consumer");
+
+// Consume some messages through handler.
+consumer.consume().expect("consume messages");
+
+// Clean up redis
+use redis::Commands;
+redis.del::<&str, bool>("my-stream").expect("del");
+```
+
+## Consumer groups usage:
+
+```rust
+use redis_stream::consumer::{Consumer, ConsumerOpts, Message};
+
+let redis_url =
+  std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://127.0.0.1:6379".to_string());
+
+let mut redis = redis::Client::open(redis_url)
+  .expect("client")
+  .get_connection()
+  .expect("connection");
+
+// Message handler
+let handler = |_id: &str, message: &Message| {
+  // do something
+  Ok(())
+};
+
+// Consumer config
+let opts = ConsumerOpts::default().group("my-group", "worker.1");
+let mut consumer = Consumer::init(&mut redis, "my-stream-2", handler, opts).unwrap();
+
+// Consume some messages through handler.
+consumer.consume().expect("consume messages");
+
+// Clean up redis
+use redis::Commands;
+redis.xgroup_destroy::<&str, &str, bool>("my-stream-2", "my-group").expect("xgroup destroy");
+redis.del::<&str, bool>("my-stream-2").expect("del");
+```
+
+## Development
+
+If you want to develop on the library, there are a few commands provided by the
+makefile.
+
+Run `make help` to get more info.
+
+For testing, a `docker-compose.yml` file is also available if you need to start a local redis instance:
+
+```sh
+$ docker-compose up -d
+$ make test
 ```
 ## License
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+# If you need a redis for running tests:
+#
+#     docker-compose up -d
+#     make test
+#
+version: "3"
+services:
+  redis:
+    image: redis:6-alpine
+    ports:
+      - 6379:6379
+    command: ["redis-server"]

--- a/scripts/bump-cargo.sh
+++ b/scripts/bump-cargo.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -exu
+
+cargo bump "$(cat ./VERSION)"
+git add Cargo.toml

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -exu
+
+# Run ./scripts/release.sh first and set your ~/.cargo/credentials
+
+git push --follow-tags origin master
+cargo login
+cargo publish

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -exu
+
+if [ -z "$(git status --untracked-files=no --porcelain)" ]; then
+  cargo install cargo-bump
+  npx standard-version -a --scripts.postbump "./scripts/bump-cargo.sh"
+else
+  echo "Uncommitted changes detected, please commit before release."
+  exit 1
+fi

--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -1,0 +1,560 @@
+use anyhow::{bail, Context, Result};
+use redis_streams::{Connection, RedisResult, StreamCommands, StreamReadOptions, Value};
+use std::collections::HashMap;
+
+pub use super::types::{ConsumerOpts, StartPosition};
+
+pub type Message = HashMap<String, Value>;
+// pub type MessageHandler = Fn(&mut Connection, &str, &Message) -> Result<()>;
+
+// A Consumer or Group Consumer handling connection to Redis and able to consume
+// messages.
+pub struct Consumer<'a, F>
+where
+  F: FnMut(&str, &Message) -> Result<()>,
+{
+  pub consumer_name: Option<String>,
+  pub group_name: Option<String>,
+  pub handled_messages: u32,
+  pub handler: F,
+  pub is_group_consumer: bool,
+  pub next_pos: String,
+  pub process_pending: bool,
+  // raise_errors: bool,
+  pub redis: &'a mut Connection,
+  pub stream: String,
+  pub timeout: usize,
+}
+
+impl<'a, F> Consumer<'a, F>
+where
+  F: FnMut(&str, &Message) -> Result<()>,
+{
+  /// Initializes a new `stream::Consumer`.
+  pub fn init(
+    redis: &'a mut Connection,
+    stream: &str,
+    handler: F,
+    opts: ConsumerOpts,
+  ) -> Result<Self> {
+    let timeout = opts.timeout;
+    let group_name = opts.group_name;
+    let consumer_name = opts.consumer_name;
+    let create_stream_if_not_exists = opts.create_stream_if_not_exists;
+    let process_pending = opts.process_pending;
+    let start_pos = opts.start_pos;
+
+    // Guards
+    match (group_name.as_ref(), consumer_name.as_ref()) {
+      (Some(_), None) => {
+        bail!("consumer groups need group_name and consumer_name (only group_name was specified)")
+      }
+      (None, Some(_)) => bail!(
+        "consumer groups need group_name and consumer_name (only consumer_name was specified)"
+      ),
+      _ => (),
+    }
+
+    let is_group_consumer = group_name.as_ref().is_some() && consumer_name.as_ref().is_some();
+
+    let (group_create_pos, consumer_start_pos) = positions(&group_name, process_pending, start_pos);
+
+    if consumer_name.is_some() {
+      ensure_stream_and_group(
+        redis,
+        &stream,
+        group_name.as_ref().unwrap(),
+        &group_create_pos.unwrap(),
+        create_stream_if_not_exists,
+      )?;
+    }
+
+    Ok(Consumer {
+      consumer_name,
+      group_name,
+      handled_messages: 0,
+      handler,
+      is_group_consumer,
+      next_pos: consumer_start_pos,
+      process_pending,
+      redis,
+      stream: stream.to_string(),
+      timeout,
+    })
+  }
+
+  /// Handles new messages from the stream, dispatching them to the given
+  /// handler.
+  pub fn consume(&mut self) -> Result<()> {
+    let opts =
+      if let (Some(group_name), Some(consumer_name)) = (&self.group_name, &self.consumer_name) {
+        // We have a consumer group
+        // XREADGROUP GROUP <group_name> <consumer_name> BLOCK <timeout> STREAMS <stream> <start_pos>
+        StreamReadOptions::default()
+          .group(group_name, consumer_name)
+          .block(self.timeout)
+      } else {
+        // We have a simple consumer
+        // XREAD BLOCK <timeout> STREAMS <stream> <start_pos>
+        StreamReadOptions::default().block(self.timeout)
+      };
+
+    let stream_results = &self
+      .redis
+      .xread_options(&[&self.stream], &[&self.next_pos], opts)?;
+
+    if !stream_results.keys.is_empty() {
+      let stream = &stream_results.keys[0];
+
+      if self.is_group_consumer && self.process_pending && stream.ids.is_empty() {
+        // We ran out of pending results, let's switch to processing most
+        // recent.
+        self.process_pending = false;
+        self.next_pos = String::from(">");
+        return self.consume();
+      } else {
+        // Process the results and set the next position to consume from
+        for message in &stream.ids {
+          // Keep next_post if we are in a consumer-group and it's already `>`
+          if self.next_pos != ">" {
+            // or take the last id
+            self.next_pos = message.id.to_string();
+          }
+          let items = &message.map;
+
+          self.process_message(&message.id, items)?;
+        }
+      }
+    }
+
+    Ok(())
+  }
+
+  /// Process a message, acknowledging it's id to redis if required.
+  fn process_message(&mut self, id: &str, message: &Message) -> Result<()> {
+    // Call handler
+    (self.handler)(id, message)?;
+    self.handled_messages += 1;
+    // XACK if needed
+    if self.is_group_consumer {
+      let _ack_count: i32 = self
+        .redis
+        .xack(&self.stream, self.group_name.as_ref().unwrap(), &[id])
+        .unwrap();
+    }
+    Ok(())
+  }
+}
+
+// Helpers
+
+/// Creates Stream and Consumer-Group if required.
+fn ensure_stream_and_group(
+  redis: &mut Connection,
+  stream: &str,
+  group_name: &str,
+  create_pos: &str,
+  create_stream_if_not_exists: bool,
+) -> Result<()> {
+  let mut result: RedisResult<String> = if create_stream_if_not_exists {
+    redis.xgroup_create_mkstream(stream, group_name, create_pos)
+  } else {
+    redis.xgroup_create(stream, group_name, create_pos)
+  };
+
+  // Ignore BUSYGROUP errors, it means the group already exists, which is fine.
+  if let Err(err) = &result {
+    if err.to_string() == "BUSYGROUP: Consumer Group name already exists" {
+      result = Ok("OK".to_string());
+    }
+  }
+
+  result.context(format!(
+    "failed to run redis command:\n\
+     XGROUP CREATE {} {} {}{}",
+    stream,
+    group_name,
+    create_pos,
+    if create_stream_if_not_exists {
+      " MKSTREAM"
+    } else {
+      ""
+    }
+  ))?;
+
+  Ok(())
+}
+
+/// Returns the tuple (`group_create_position`, `consumer_start_position`)
+/// containing position args for `XGROUP CREATE`, `XREADGROUP` or `XREAD`:
+/// - `group_create_pos`: Position to start in the stream if group is upserted
+///   - for consumer-group:
+///     - `0` for the beginning of the stream
+///     - `$` for the end of the stream (new messages only)
+///     - `<id>` for a specific id
+/// - `start_pos`: Position to start in the stream for consumer
+///   - for groups-consumers:
+///     - `0` for pending messages
+///     - `>` for new messages
+///     - `<id>` for a specific id
+///   - for stream-consumers:
+///     - `0` for the beginning of the stream
+///     - `$` for the end of the stream
+///     - `<id>` for a specific id
+fn positions(
+  group_name: &Option<String>,
+  process_pending: bool,
+  start_pos: StartPosition,
+) -> (Option<String>, String) {
+  use StartPosition::*;
+  let (group_create_position, consumer_start_position) =
+    match (group_name, process_pending, start_pos) {
+      // no group name: we'll simply XREAD starting from beginning or end
+      (None, _, StartOfStream) => (None, String::from("0")),
+      (None, _, EndOfStream) => (None, String::from("$")),
+      (None, _, Other(id)) => (None, id),
+      // group name and process pending:
+      (_, true, StartOfStream) => str_to_positions("0", "0"),
+      (_, true, EndOfStream) => str_to_positions("$", "0"),
+      (_, true, Other(id)) => (Some(id), String::from("0")),
+      // group name and don't process pending
+      (_, false, StartOfStream) => str_to_positions("0", ">"),
+      (_, false, EndOfStream) => str_to_positions("$", ">"),
+      (_, false, Other(id)) => (Some(id.clone()), id),
+    };
+
+  (group_create_position, consumer_start_position)
+}
+
+// mainly converts &str to Strings...
+#[inline]
+fn str_to_positions(a: &str, b: &str) -> (Option<String>, String) {
+  (Some(a.to_string()), b.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::test_helpers::*;
+  use redis::FromRedisValue;
+
+  fn delete_group(stream: &str, group: &str) {
+    redis_connection()
+      .xgroup_destroy::<&str, &str, bool>(stream, group)
+      .unwrap();
+  }
+
+  fn print_message(_id: &str, message: &Message) -> Result<()> {
+    for (k, v) in message {
+      println!("{}: {}", k, String::from_redis_value(&v).unwrap());
+    }
+    Ok(())
+  }
+
+  #[test]
+  fn test_init_options() {
+    // TODO
+    // - Test with default values
+    // - Test with custom values
+    // - Test guards (group_name or consumer_name)
+  }
+
+  #[test]
+  fn test_init() {
+    let mut redis = redis_connection();
+    let mut redis_c = redis_connection();
+    let stream = &format!("test-stream-{}", random_string(25));
+    let group = &format!("test-group-{}", random_string(25));
+    let consumer_name = &format!("test-consumer-{}", random_string(25));
+
+    // it creates an empty stream (if opt)
+    assert!(!key_exists(&mut redis, stream));
+
+    let opts = ConsumerOpts::default()
+      .create_stream_if_not_exists(true)
+      .group_name(group)
+      .consumer_name(consumer_name);
+    Consumer::init(&mut redis_c, &stream, print_message, opts).unwrap();
+    assert!(key_exists(&mut redis, stream));
+    // with length = 0
+    let len: usize = redis.xlen(stream).unwrap();
+    assert_eq!(len, 0);
+
+    delete_group(stream, group);
+    delete_stream(stream);
+
+    // it doesn't create an empty stream (if !opt)
+    assert!(!key_exists(&mut redis, stream));
+    let opts = ConsumerOpts::default()
+      .create_stream_if_not_exists(false)
+      .group_name(group)
+      .consumer_name(consumer_name);
+    assert!(Consumer::init(&mut redis_c, stream, print_message, opts).is_err());
+    assert!(!key_exists(&mut redis, stream));
+  }
+
+  #[test]
+  fn test_consume() {
+    use std::thread;
+    use std::time::Duration;
+
+    let group = &format!("test-group-{}", random_string(25));
+    let consumer_name = &format!("test-consumer-{}", random_string(25));
+    let stream = &format!("test-stream-{}", random_string(25));
+    let mut redis = redis_connection();
+    let mut redis_c = redis_connection();
+
+    crate::produce(&mut redis, stream, &[("key", "value_1")]).unwrap();
+
+    // simple consumers
+    {
+      // it processes old messages if StartOfStream
+      {
+        let mut messages = vec![];
+        let handler = |_id: &str, message: &Message| {
+          messages.push(message.clone());
+          Ok(())
+        };
+        let opts = ConsumerOpts::default().start_pos(StartPosition::StartOfStream);
+        let mut consumer = Consumer::init(&mut redis_c, stream, handler, opts).unwrap();
+
+        consumer.consume().unwrap();
+        let value = String::from_redis_value(messages.pop().unwrap().get("key").unwrap()).unwrap();
+        assert_eq!(value, "value_1".to_string());
+      }
+
+      // it skips old messages if EndOfStream
+      {
+        let messages = &mut vec![];
+        let handler = |_id: &str, message: &Message| {
+          messages.push(message.clone());
+          Ok(())
+        };
+        let opts = ConsumerOpts::default().start_pos(StartPosition::EndOfStream);
+        let mut consumer = Consumer::init(&mut redis_c, stream, handler, opts).unwrap();
+        let stream_name = stream.clone();
+        let child = thread::spawn(move || {
+          // allow consumer time to call consume
+          thread::sleep(Duration::from_millis(500));
+          let mut redis = redis_connection();
+          crate::produce(&mut redis, &stream_name, &[("key", "value_2")]).unwrap();
+        });
+
+        consumer.consume().unwrap();
+        child.join().unwrap();
+        let value = String::from_redis_value(messages.pop().unwrap().get("key").unwrap()).unwrap();
+        assert_eq!(value, "value_2".to_string());
+      }
+    }
+
+    // consumer groups
+    {
+      // it skips old messages if EndOfStream
+      {
+        let mut messages = vec![];
+        let handler = |_id: &str, message: &Message| {
+          messages.push(message.clone());
+          bail!("I don't ack message");
+        };
+        let opts = ConsumerOpts::default()
+          .group_name(group)
+          .start_pos(StartPosition::EndOfStream)
+          .consumer_name(consumer_name)
+          .process_pending(true);
+        let mut consumer = Consumer::init(&mut redis_c, stream, handler, opts).unwrap();
+        let stream_name = stream.clone();
+        let child = thread::spawn(move || {
+          // allow consumer time to call consume
+          thread::sleep(Duration::from_millis(500));
+          let mut redis = redis_connection();
+          crate::produce(&mut redis, &stream_name, &[("key", "value_3")]).unwrap();
+          crate::produce(&mut redis, &stream_name, &[("key", "value_4")]).unwrap();
+        });
+
+        // skip the error so we can check for pending messages in next test
+        consumer.consume().unwrap_or(());
+        child.join().unwrap();
+        let value = String::from_redis_value(messages.pop().unwrap().get("key").unwrap()).unwrap();
+        assert_eq!(value, "value_3".to_string());
+      }
+
+      // it processes pending messages if process pending is true
+      {
+        let mut messages = vec![];
+        let handler = |_id: &str, message: &Message| {
+          messages.push(message.clone());
+          bail!("I don't ack message");
+        };
+        let opts = ConsumerOpts::default()
+          .group_name(group)
+          .start_pos(StartPosition::EndOfStream)
+          .consumer_name(consumer_name)
+          .process_pending(true);
+        let mut consumer = Consumer::init(&mut redis_c, stream, handler, opts).unwrap();
+        // skip the error so we can check pending messages are skipped in next test
+        consumer.consume().unwrap_or(());
+        let value = String::from_redis_value(messages.pop().unwrap().get("key").unwrap()).unwrap();
+        assert_eq!(value, "value_3".to_string());
+      }
+
+      // it skips pending messages if process_pending is false
+      {
+        let mut messages = vec![];
+        let handler = |_id: &str, message: &Message| {
+          messages.push(message.clone());
+          Ok(())
+        };
+        let opts = ConsumerOpts::default()
+          .group_name(group)
+          .start_pos(StartPosition::EndOfStream)
+          .consumer_name(consumer_name)
+          .process_pending(false);
+        let mut consumer = Consumer::init(&mut redis_c, stream, handler, opts).unwrap();
+        consumer.consume().unwrap();
+        let value = String::from_redis_value(messages.pop().unwrap().get("key").unwrap()).unwrap();
+        assert_eq!(value, "value_4".to_string());
+      }
+
+      // it ack messages
+      {
+        let mut messages = vec![];
+        let handler = |_id: &str, message: &Message| {
+          messages.push(message.clone());
+          Ok(())
+        };
+        let opts = ConsumerOpts::default()
+          .group_name(group)
+          .start_pos(StartPosition::EndOfStream)
+          .consumer_name(consumer_name)
+          .process_pending(true);
+        let mut consumer = Consumer::init(&mut redis_c, stream, handler, opts).unwrap();
+        consumer.consume().unwrap();
+        let value = String::from_redis_value(messages.pop().unwrap().get("key").unwrap()).unwrap();
+        assert_eq!(value, "value_3".to_string());
+
+        let mut messages = vec![];
+        let handler = |_id: &str, message: &Message| {
+          messages.push(message.clone());
+          Ok(())
+        };
+        let opts = ConsumerOpts::default()
+          .group_name(group)
+          .start_pos(StartPosition::EndOfStream)
+          .consumer_name(consumer_name)
+          .process_pending(true);
+        let mut consumer = Consumer::init(&mut redis_c, stream, handler, opts).unwrap();
+        consumer.consume().unwrap();
+        assert!(messages.is_empty());
+      }
+
+      delete_group(stream, group);
+
+      // it processes old messages if StartOfStream
+      {
+        // when process_pending is false
+        let mut messages = vec![];
+        let handler = |_id: &str, message: &Message| {
+          messages.push(message.clone());
+          Ok(())
+        };
+        let opts = ConsumerOpts::default()
+          .group_name(group)
+          .start_pos(StartPosition::StartOfStream)
+          .consumer_name(consumer_name)
+          .process_pending(false);
+        let mut consumer = Consumer::init(&mut redis_c, stream, handler, opts).unwrap();
+        consumer.consume().unwrap();
+        let value = String::from_redis_value(messages.pop().unwrap().get("key").unwrap()).unwrap();
+        assert_eq!(value, "value_4".to_string());
+        let value = String::from_redis_value(messages.pop().unwrap().get("key").unwrap()).unwrap();
+        assert_eq!(value, "value_3".to_string());
+        let value = String::from_redis_value(messages.pop().unwrap().get("key").unwrap()).unwrap();
+        assert_eq!(value, "value_2".to_string());
+        let value = String::from_redis_value(messages.pop().unwrap().get("key").unwrap()).unwrap();
+        assert_eq!(value, "value_1".to_string());
+
+        delete_group(stream, group);
+
+        // when process_pending is true
+        let mut messages = vec![];
+        let handler = |_id: &str, message: &Message| {
+          messages.push(message.clone());
+          Ok(())
+        };
+        let opts = ConsumerOpts::default()
+          .group_name(group)
+          .start_pos(StartPosition::StartOfStream)
+          .consumer_name(consumer_name)
+          .process_pending(true);
+        let mut consumer = Consumer::init(&mut redis_c, stream, handler, opts).unwrap();
+        consumer.consume().unwrap();
+        let value = String::from_redis_value(messages.pop().unwrap().get("key").unwrap()).unwrap();
+        assert_eq!(value, "value_4".to_string());
+        let value = String::from_redis_value(messages.pop().unwrap().get("key").unwrap()).unwrap();
+        assert_eq!(value, "value_3".to_string());
+        let value = String::from_redis_value(messages.pop().unwrap().get("key").unwrap()).unwrap();
+        assert_eq!(value, "value_2".to_string());
+        let value = String::from_redis_value(messages.pop().unwrap().get("key").unwrap()).unwrap();
+        assert_eq!(value, "value_1".to_string());
+      }
+
+      delete_group(stream, group);
+
+      // it skip old messages if EndOfStream
+      {
+        // when process_pending is false
+        let mut messages = vec![];
+        let handler = |_id: &str, message: &Message| {
+          messages.push(message.clone());
+          Ok(())
+        };
+        let opts = ConsumerOpts::default()
+          .group_name(group)
+          .start_pos(StartPosition::EndOfStream)
+          .consumer_name(consumer_name)
+          .process_pending(false);
+        let mut consumer = Consumer::init(&mut redis_c, stream, handler, opts).unwrap();
+        consumer.consume().unwrap();
+        assert!(messages.is_empty());
+
+        delete_group(stream, group);
+
+        // when process_pending is true
+        let mut messages = vec![];
+        let handler = |_id: &str, message: &Message| {
+          messages.push(message.clone());
+          Ok(())
+        };
+        let opts = ConsumerOpts::default()
+          .group_name(group)
+          .start_pos(StartPosition::EndOfStream)
+          .consumer_name(consumer_name)
+          .process_pending(true);
+        let mut consumer = Consumer::init(&mut redis_c, stream, handler, opts).unwrap();
+        consumer.consume().unwrap();
+        assert!(messages.is_empty());
+      }
+    }
+
+    delete_group(stream, group);
+    delete_stream(stream);
+  }
+
+  // note: `test_process_messages` is already tested by `test_consume`
+
+  // note: `test_positions` is already tested by `test_consume` (but adding more
+  // tests wouldn't hurt)
+
+  #[test]
+  fn test_ensure_stream_and_group() -> Result<()> {
+    let mut redis = redis_connection();
+
+    delete_stream("test-stream");
+    ensure_stream_and_group(&mut redis, "test-stream", "test-group", "0", true)
+      .context("failed to produce entry to stream")?;
+    ensure_stream_and_group(&mut redis, "test-stream", "test-group", "0", true)
+      .context("failed to produce entry to stream")?;
+
+    Ok(())
+  }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,77 @@
+use anyhow::{Context, Result};
+use redis_streams::{Connection, StreamCommands};
+
+pub mod consumer;
+pub mod types;
+
+/// Produces a new message into a Redis stream.
+pub fn produce(
+  redis: &mut Connection,
+  stream: &str,
+  key_values: &[(&str, &str)],
+) -> Result<String> {
+  let id = redis
+    .xadd::<&str, &str, &str, &str, String>(stream, "*", key_values)
+    .context(format!(
+      "failed to run redis command:\n\
+       XADD {} * {}",
+      stream,
+      key_values
+        .iter()
+        .map(|(k, v)| format!("{} {}", k, v))
+        .collect::<Vec<String>>()
+        .join(" ")
+    ))?;
+  Ok(id)
+}
+
+#[cfg(test)]
+pub mod test_helpers {
+  use rand::distributions::Alphanumeric;
+  use rand::{thread_rng, Rng};
+  use redis_streams::{client_open, Commands, Connection, RedisResult};
+
+  pub fn delete_stream(stream: &str) {
+    redis_connection().del::<&str, bool>(stream).unwrap();
+  }
+
+  pub fn key_exists(redis: &mut Connection, key: &str) -> bool {
+    let exists: RedisResult<bool> = redis.exists(key);
+    exists.unwrap()
+  }
+
+  pub fn redis_connection() -> Connection {
+    let redis_url =
+      std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://127.0.0.1:6379".to_string());
+    client_open(redis_url)
+      .expect("failed to open redis client")
+      .get_connection()
+      .expect("failed to get redis connection")
+  }
+
+  pub fn random_string(n: usize) -> String {
+    thread_rng().sample_iter(&Alphanumeric).take(n).collect()
+  }
+}
+
 #[cfg(test)]
 mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
+  use super::*;
+  use crate::test_helpers::*;
+  use regex::Regex;
+
+  #[test]
+  fn test_produce() -> Result<()> {
+    let mut redis = redis_connection();
+
+    let key_values = &[("temperature", "31")];
+    let stream = &format!("test-stream-{}", random_string(25));
+    let id =
+      produce(&mut redis, stream, key_values).context("failed to produce entry to stream")?;
+    let re = Regex::new(r"^\d+-\d+$").unwrap();
+    assert!(re.is_match(&id), "{:?} doesn't match Regex: {:?}", id, re);
+    delete_stream(stream);
+
+    Ok(())
+  }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use redis_streams::{Connection, StreamCommands};
+use redis::{Commands, Connection};
 
 pub mod consumer;
 pub mod types;
@@ -29,7 +29,7 @@ pub fn produce(
 pub mod test_helpers {
   use rand::distributions::Alphanumeric;
   use rand::{thread_rng, Rng};
-  use redis_streams::{client_open, Commands, Connection, RedisResult};
+  use redis::{Commands, Connection, RedisResult};
 
   pub fn delete_stream(stream: &str) {
     redis_connection().del::<&str, bool>(stream).unwrap();
@@ -43,7 +43,7 @@ pub mod test_helpers {
   pub fn redis_connection() -> Connection {
     let redis_url =
       std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://127.0.0.1:6379".to_string());
-    client_open(redis_url)
+    redis::Client::open(redis_url)
       .expect("failed to open redis client")
       .get_connection()
       .expect("failed to get redis connection")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,74 @@
+//! Simple API for producing and consuming redis streams.
+//!
+//! # Basic usage:
+//!
+//! ```
+//! use redis_stream::consumer::{Consumer, ConsumerOpts, Message};
+//!
+//! let redis_url =
+//!   std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://127.0.0.1:6379".to_string());
+//!
+//! let mut redis = redis::Client::open(redis_url)
+//!   .expect("client")
+//!   .get_connection()
+//!   .expect("connection");
+//!
+//! // Message handler
+//! let handler = |_id: &str, message: &Message| {
+//!   // do something
+//!   Ok(())
+//! };
+//!
+//! // Consumer config
+//! let opts = ConsumerOpts::default();
+//! let mut consumer = Consumer::init(&mut redis, "my-stream", handler, opts).expect("consumer");
+//!
+//! // Consume some messages through handler.
+//! consumer.consume().expect("consume messages");
+//!
+//! // Clean up redis
+//! use redis::Commands;
+//! redis.del::<&str, bool>("my-stream").expect("del");
+//! ```
+//!
+//! # Consumer groups usage:
+//!
+//! ```
+//! use redis_stream::consumer::{Consumer, ConsumerOpts, Message};
+//!
+//! let redis_url =
+//!   std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://127.0.0.1:6379".to_string());
+//!
+//! let mut redis = redis::Client::open(redis_url)
+//!   .expect("client")
+//!   .get_connection()
+//!   .expect("connection");
+//!
+//! // Message handler
+//! let handler = |_id: &str, message: &Message| {
+//!   // do something
+//!   Ok(())
+//! };
+//!
+//! // Consumer config
+//! let opts = ConsumerOpts::default().group("my-group", "worker.1");
+//! let mut consumer = Consumer::init(&mut redis, "my-stream-2", handler, opts).unwrap();
+//!
+//! // Consume some messages through handler.
+//! consumer.consume().expect("consume messages");
+//!
+//! // Clean up redis
+//! use redis::Commands;
+//! redis.xgroup_destroy::<&str, &str, bool>("my-stream-2", "my-group").expect("xgroup destroy");
+//! redis.del::<&str, bool>("my-stream-2").expect("del");
+//! ```
+//!
+//! see:
+//!
+//! - [`ConsumerOpts`](types/struct.ConsumerOpts.html)
+//! - [`Consumer::init`](consumer/struct.Consumer.html#method.init)
+//! - [`Consumer::consume`](consumer/struct.Consumer.html#method.consume)
+//! - [`produce`](fn.produce.html)
 use anyhow::{Context, Result};
 use redis::{Commands, Connection};
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,3 +1,5 @@
+//! Defines types to use with the consumer commands.
+
 #[derive(Clone, Debug)]
 pub enum StartPosition {
   EndOfStream,
@@ -5,7 +7,33 @@ pub enum StartPosition {
   StartOfStream,
 }
 
-/// Builder options for `Consumer::init`.
+/// Builder options for [`Consumer::init`].
+///
+/// Configuration settings for stream consumers (simple or group).
+///
+/// # Basic usage
+///
+/// ```
+/// use redis_stream::consumer::{ConsumerOpts, StartPosition};
+///
+/// let opts = ConsumerOpts::default().start_pos(StartPosition::StartOfStream);
+/// ```
+///
+/// # Group consumer
+///
+/// Specifying a `group` (with `group_name` and `consumer_name`), will instruct
+/// the [`Consumer`] to use consumer groups specific commands (like `XGROUP
+/// CREATE`, `XREADGROUP` or `XACK`).
+///
+/// ```
+/// use redis_stream::consumer::{ConsumerOpts, StartPosition};
+///
+/// let opts = ConsumerOpts::default()
+///   .group("my-group", "consumer.1")
+///   .start_pos(StartPosition::StartOfStream);
+/// ```
+/// [`Consumer`]: ../consumer/struct.Consumer.html
+/// [`Consumer::init`]:../consumer/struct.Consumer.html#method.init
 #[derive(Debug)]
 pub struct ConsumerOpts {
   pub count: Option<usize>,

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,0 +1,71 @@
+#[derive(Clone, Debug)]
+pub enum StartPosition {
+  EndOfStream,
+  Other(String),
+  StartOfStream,
+}
+
+/// Builder options for `Consumer::init`.
+#[derive(Debug)]
+pub struct ConsumerOpts {
+  pub consumer_name: Option<String>,
+  /// Maximum number of messages to read from the stream in one batch.
+  pub count: usize,
+  pub create_stream_if_not_exists: bool,
+  pub group_name: Option<String>,
+  pub process_pending: bool,
+  pub start_pos: StartPosition,
+  /// Maximum blocking time to wait for messages on Redis.
+  pub timeout: usize,
+}
+
+impl Default for ConsumerOpts {
+  fn default() -> Self {
+    Self {
+      consumer_name: None,
+      count: 10,
+      create_stream_if_not_exists: true,
+      group_name: None,
+      process_pending: true,
+      start_pos: StartPosition::EndOfStream,
+      timeout: 2_000,
+    }
+  }
+}
+
+impl ConsumerOpts {
+  pub fn consumer_name(mut self, consumer_name: &str) -> Self {
+    self.consumer_name = Some(consumer_name.to_string());
+    self
+  }
+
+  pub fn count(mut self, count: usize) -> Self {
+    self.count = count;
+    self
+  }
+
+  pub fn create_stream_if_not_exists(mut self, create_stream_if_not_exists: bool) -> Self {
+    self.create_stream_if_not_exists = create_stream_if_not_exists;
+    self
+  }
+
+  pub fn group_name(mut self, group_name: &str) -> Self {
+    self.group_name = Some(group_name.to_string());
+    self
+  }
+
+  pub fn process_pending(mut self, process_pending: bool) -> Self {
+    self.process_pending = process_pending;
+    self
+  }
+
+  pub fn start_pos(mut self, start_pos: StartPosition) -> Self {
+    self.start_pos = start_pos;
+    self
+  }
+
+  pub fn timeout(mut self, timeout: usize) -> Self {
+    self.timeout = timeout;
+    self
+  }
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -8,24 +8,20 @@ pub enum StartPosition {
 /// Builder options for `Consumer::init`.
 #[derive(Debug)]
 pub struct ConsumerOpts {
-  pub consumer_name: Option<String>,
-  /// Maximum number of messages to read from the stream in one batch.
-  pub count: usize,
+  pub count: Option<usize>,
   pub create_stream_if_not_exists: bool,
-  pub group_name: Option<String>,
+  pub group: Option<(String, String)>,
   pub process_pending: bool,
   pub start_pos: StartPosition,
-  /// Maximum blocking time to wait for messages on Redis.
   pub timeout: usize,
 }
 
 impl Default for ConsumerOpts {
   fn default() -> Self {
     Self {
-      consumer_name: None,
-      count: 10,
+      count: None,
       create_stream_if_not_exists: true,
-      group_name: None,
+      group: None,
       process_pending: true,
       start_pos: StartPosition::EndOfStream,
       timeout: 2_000,
@@ -34,36 +30,39 @@ impl Default for ConsumerOpts {
 }
 
 impl ConsumerOpts {
-  pub fn consumer_name(mut self, consumer_name: &str) -> Self {
-    self.consumer_name = Some(consumer_name.to_string());
-    self
-  }
-
+  /// Maximum number of message to read from the stream in one batch
   pub fn count(mut self, count: usize) -> Self {
-    self.count = count;
+    self.count = Some(count);
     self
   }
 
+  /// Create the stream in Redis before registering the group (default: `true`).
   pub fn create_stream_if_not_exists(mut self, create_stream_if_not_exists: bool) -> Self {
     self.create_stream_if_not_exists = create_stream_if_not_exists;
     self
   }
 
-  pub fn group_name(mut self, group_name: &str) -> Self {
-    self.group_name = Some(group_name.to_string());
+  /// Name of the group and consumer. Enables Redis group consumer behavior if
+  /// specified
+  pub fn group(mut self, group_name: &str, consumer_name: &str) -> Self {
+    self.group = Some((group_name.to_string(), consumer_name.to_string()));
     self
   }
 
+  /// Start by processing pending messages before switching to real time data
+  /// (default: `true`)
   pub fn process_pending(mut self, process_pending: bool) -> Self {
     self.process_pending = process_pending;
     self
   }
 
+  /// Where to start reading messages in the stream.
   pub fn start_pos(mut self, start_pos: StartPosition) -> Self {
     self.start_pos = start_pos;
     self
   }
 
+  /// Maximum ms duration to block waiting for messages.
   pub fn timeout(mut self, timeout: usize) -> Self {
     self.timeout = timeout;
     self


### PR DESCRIPTION
This adds `redis_stream::produce()` and `redis_stream::consumer::Consumer`.

Note that we removed `group_name()` and `consumer_name()` from `ConsumerOpts` in favor of `group(group_name, consumer_name)` .